### PR TITLE
Add initial tests for Toast, Dropdown, OutsideClick, FloatingElement, Forms, and bundle packages

### DIFF
--- a/src/HeadlessBlazor.Dropdown/HBDropdownTrigger.cs
+++ b/src/HeadlessBlazor.Dropdown/HBDropdownTrigger.cs
@@ -20,7 +20,8 @@ public class HBDropdownTrigger : HBElement
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
-        if (!OnClickPreventDefault)
-            UserAttributes.TryAdd("onclick", new EventCallback(this, Dropdown.ToggleAsync));
+        UserAttributes.TryAdd("onclick", OnClickPreventDefault
+            ? EventCallback.Empty
+            : new EventCallback(this, Dropdown.ToggleAsync));
     }
 }

--- a/src/HeadlessBlazor.Toast/HeadlessBlazor.Toast.csproj
+++ b/src/HeadlessBlazor.Toast/HeadlessBlazor.Toast.csproj
@@ -45,4 +45,8 @@
     <ProjectReference Include="..\HeadlessBlazor.Core\HeadlessBlazor.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="HeadlessBlazor.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownItemTests.cs
+++ b/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownItemTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace HeadlessBlazor.Tests.Dropdown;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBDropdownItem"/>, exercised through a
+/// parent <see cref="HBDropdown"/> (with outside-click detection disabled, see
+/// <see cref="HBDropdownTests"/>) so the cascaded <c>Dropdown</c> parameter is populated.
+/// </summary>
+public class HBDropdownItemTests : BunitContext
+{
+    [Fact]
+    public void Click_InvokesDropdownOnClickItem()
+    {
+        HBDropdownItem? clicked = null;
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.OnClickItem, (HBDropdownItem item) => clicked = item)
+            .Add(p => p.ChildContent, _ => (RenderTreeBuilder builder) =>
+            {
+                builder.OpenComponent<HBDropdownItem>(0);
+                builder.AddAttribute(1, "id", "item");
+                builder.CloseComponent();
+            }));
+
+        cut.Find("#item").Click();
+
+        Assert.NotNull(clicked);
+    }
+
+    [Fact]
+    public void Click_DoesNotInvokeDropdownOnClickItem_WhenStopPropagationIsSet()
+    {
+        var invoked = false;
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.OnClickItem, (HBDropdownItem _) => invoked = true)
+            .Add(p => p.ChildContent, _ => (RenderTreeBuilder builder) =>
+            {
+                builder.OpenComponent<HBDropdownItem>(0);
+                builder.AddAttribute(1, "id", "item");
+                builder.AddAttribute(2, nameof(HBDropdownItem.OnClickStopPropagation), true);
+                builder.CloseComponent();
+            }));
+
+        cut.Find("#item").Click();
+
+        Assert.False(invoked);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownItemVariantTests.cs
+++ b/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownItemVariantTests.cs
@@ -1,0 +1,26 @@
+namespace HeadlessBlazor.Tests.Dropdown;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for the element-name overrides on
+/// <see cref="HBDropdownItemLink"/> and <see cref="HBDropdownItemButton"/>. Rendered standalone
+/// (no parent <see cref="HBDropdown"/>) since the <c>Dropdown</c> cascading parameter is only
+/// needed once a click is handled, not for rendering.
+/// </summary>
+public class HBDropdownItemVariantTests : BunitContext
+{
+    [Fact]
+    public void HBDropdownItemLink_RendersAnchorElement()
+    {
+        var cut = Render<HBDropdownItemLink>();
+
+        Assert.NotNull(cut.Find("a"));
+    }
+
+    [Fact]
+    public void HBDropdownItemButton_RendersButtonElement()
+    {
+        var cut = Render<HBDropdownItemButton>();
+
+        Assert.NotNull(cut.Find("button"));
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTests.cs
+++ b/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTests.cs
@@ -1,0 +1,70 @@
+namespace HeadlessBlazor.Tests.Dropdown;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBDropdown"/>. Rendered with
+/// <see cref="HBDropdown.CloseOnOutsideClick"/> disabled so opening it never mounts
+/// <c>HBOutsideClickBehavior</c> (a JS-interop behavior bUnit's stubbed <c>IJSRuntime</c> cannot
+/// service) - these tests exercise the open/close state machine, not JS interop.
+/// </summary>
+public class HBDropdownTests : BunitContext
+{
+    [Fact]
+    public void IsOpen_DefaultsToFalse()
+    {
+        var cut = Render<HBDropdown>();
+
+        Assert.False(cut.Instance.IsOpen);
+    }
+
+    [Fact]
+    public async Task OpenAsync_SetsIsOpen_AndInvokesOnOpen()
+    {
+        var opened = 0;
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.OnOpen, (HBDropdown _) => opened++));
+
+        await cut.Instance.OpenAsync();
+
+        Assert.True(cut.Instance.IsOpen);
+        Assert.Equal(1, opened);
+    }
+
+    [Fact]
+    public async Task CloseAsync_SetsIsOpenFalse_AndInvokesOnClose()
+    {
+        var closed = 0;
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.OnClose, (HBDropdown _) => closed++));
+
+        await cut.Instance.OpenAsync();
+        await cut.Instance.CloseAsync();
+
+        Assert.False(cut.Instance.IsOpen);
+        Assert.Equal(1, closed);
+    }
+
+    [Fact]
+    public async Task ToggleAsync_TogglesIsOpen()
+    {
+        var cut = Render<HBDropdown>(ps => ps.Add(p => p.CloseOnOutsideClick, false));
+
+        await cut.Instance.ToggleAsync();
+        Assert.True(cut.Instance.IsOpen);
+
+        await cut.Instance.ToggleAsync();
+        Assert.False(cut.Instance.IsOpen);
+    }
+
+    [Fact]
+    public async Task OnClickItem_DefaultsToClosingTheDropdown_WhenNoHandlerProvided()
+    {
+        var cut = Render<HBDropdown>(ps => ps.Add(p => p.CloseOnOutsideClick, false));
+        await cut.Instance.OpenAsync();
+
+        await cut.Instance.OnClickItem.InvokeAsync(null!);
+
+        Assert.False(cut.Instance.IsOpen);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTests.cs
+++ b/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTests.cs
@@ -63,7 +63,7 @@ public class HBDropdownTests : BunitContext
         var cut = Render<HBDropdown>(ps => ps.Add(p => p.CloseOnOutsideClick, false));
         await cut.Instance.OpenAsync();
 
-        await cut.Instance.OnClickItem.InvokeAsync(null!);
+        await cut.InvokeAsync(() => cut.Instance.OnClickItem.InvokeAsync(null!));
 
         Assert.False(cut.Instance.IsOpen);
     }

--- a/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTriggerTests.cs
+++ b/tests/HeadlessBlazor.Tests/Dropdown/HBDropdownTriggerTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace HeadlessBlazor.Tests.Dropdown;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBDropdownTrigger"/>, exercised through a
+/// parent <see cref="HBDropdown"/> (with outside-click detection disabled, see
+/// <see cref="HBDropdownTests"/>) so the cascaded <c>Dropdown</c> parameter is populated.
+/// </summary>
+public class HBDropdownTriggerTests : BunitContext
+{
+    [Fact]
+    public void RendersButtonElement_ByDefault()
+    {
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.ChildContent, _ => (RenderTreeBuilder builder) =>
+            {
+                builder.OpenComponent<HBDropdownTrigger>(0);
+                builder.CloseComponent();
+            }));
+
+        Assert.NotNull(cut.Find("button"));
+    }
+
+    [Fact]
+    public void Click_TogglesTheDropdown()
+    {
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.ChildContent, _ => (RenderTreeBuilder builder) =>
+            {
+                builder.OpenComponent<HBDropdownTrigger>(0);
+                builder.CloseComponent();
+            }));
+
+        cut.Find("button").Click();
+
+        Assert.True(cut.Instance.IsOpen);
+    }
+
+    [Fact]
+    public void Click_DoesNotToggleTheDropdown_WhenPreventDefaultIsSet()
+    {
+        var cut = Render<HBDropdown>(ps => ps
+            .Add(p => p.CloseOnOutsideClick, false)
+            .Add(p => p.ChildContent, _ => (RenderTreeBuilder builder) =>
+            {
+                builder.OpenComponent<HBDropdownTrigger>(0);
+                builder.AddAttribute(1, nameof(HBDropdownTrigger.OnClickPreventDefault), true);
+                builder.CloseComponent();
+            }));
+
+        cut.Find("button").Click();
+
+        Assert.False(cut.Instance.IsOpen);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/FloatingElement/HBFloatBehaviorTests.cs
+++ b/tests/HeadlessBlazor.Tests/FloatingElement/HBFloatBehaviorTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.FloatingElement;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBFloatBehavior"/>. As noted in CLAUDE.md,
+/// bUnit stubs <c>IJSRuntime</c> and cannot verify the real effects of JS-interop behaviors, so
+/// this asserts the .NET-side disposal guard rather than driving the component through its
+/// JS-dependent render lifecycle. Positioning itself is verified manually via the docs site.
+/// </summary>
+public class HBFloatBehaviorTests
+{
+    [Fact]
+    public async Task DisposeAsync_DoesNotThrow_WhenNeverInitialized()
+    {
+        var behavior = new HBFloatBehavior { Anchor = default, Content = default };
+
+        await behavior.DisposeAsync();
+    }
+}

--- a/tests/HeadlessBlazor.Tests/FloatingElement/HBFloatOptionsTests.cs
+++ b/tests/HeadlessBlazor.Tests/FloatingElement/HBFloatOptionsTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace HeadlessBlazor.Tests.FloatingElement;
+
+/// <summary>
+/// Layer 1 (pure logic) tests for <see cref="HBFloatOptions"/> and the
+/// <see cref="HBFloatAlignment"/>/<see cref="HBFloatSide"/> enums it carries. These options are
+/// serialized to JSON and passed to the JS side (see <c>HBFloatBehavior.razor</c>'s
+/// <c>createInstance</c>/<c>updateOptions</c> calls), so the <see cref="System.Text.Json.Serialization.JsonStringEnumConverter"/>
+/// on each enum - which is what makes that payload readable by the JS module rather than raw
+/// integers - is worth covering directly.
+/// </summary>
+public class HBFloatOptionsTests
+{
+    [Fact]
+    public void RecordEquality_IsValueBased()
+    {
+        var a = new HBFloatOptions { Alignment = HBFloatAlignment.Center, Side = HBFloatSide.Bottom };
+        var b = new HBFloatOptions { Alignment = HBFloatAlignment.Center, Side = HBFloatSide.Bottom };
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void RecordEquality_DiffersWhenValuesDiffer()
+    {
+        var a = new HBFloatOptions { Alignment = HBFloatAlignment.Start };
+        var b = new HBFloatOptions { Alignment = HBFloatAlignment.End };
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Alignment_SerializesAsString()
+    {
+        var json = JsonSerializer.Serialize(HBFloatAlignment.Center);
+
+        Assert.Equal("\"Center\"", json);
+    }
+
+    [Fact]
+    public void Side_SerializesAsString()
+    {
+        var json = JsonSerializer.Serialize(HBFloatSide.Bottom);
+
+        Assert.Equal("\"Bottom\"", json);
+    }
+
+    [Fact]
+    public void Options_WithUnsetValues_SerializeAsNull()
+    {
+        var json = JsonSerializer.Serialize(new HBFloatOptions());
+
+        Assert.Equal("""{"Alignment":null,"Side":null}""", json);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Forms/HBEditContextTests.cs
+++ b/tests/HeadlessBlazor.Tests/Forms/HBEditContextTests.cs
@@ -1,0 +1,51 @@
+namespace HeadlessBlazor.Tests.Forms;
+
+/// <summary>
+/// Layer 1 (pure logic) tests for <see cref="HBEditContext{TModel}"/>: lazy creation of the
+/// underlying <see cref="Microsoft.AspNetCore.Components.Forms.EditContext"/>/message store, and
+/// the validity/revalidation helpers built on top of them.
+/// </summary>
+public class HBEditContextTests
+{
+    private sealed class Person
+    {
+        public string? Name { get; set; }
+    }
+
+    [Fact]
+    public void Context_IsCreatedForModel_AndCachedAcrossAccesses()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        Assert.Same(editContext.Context, editContext.Context);
+    }
+
+    [Fact]
+    public void IsValid_IsTrue_WhenNoValidationMessagesHaveBeenAdded()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        Assert.True(editContext.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_IsFalse_AfterACustomErrorIsAdded()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        editContext.ValidationErrors.Add(x => x.Name, "Name is required.");
+
+        Assert.False(editContext.IsValid());
+    }
+
+    [Fact]
+    public void Revalidate_ClearsPreviouslyAddedCustomErrors()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+        editContext.ValidationErrors.Add(x => x.Name, "Name is required.");
+
+        editContext.Revalidate();
+
+        Assert.True(editContext.IsValid());
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Forms/HBValidationMessageStoreTests.cs
+++ b/tests/HeadlessBlazor.Tests/Forms/HBValidationMessageStoreTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components.Forms;
+
 namespace HeadlessBlazor.Tests.Forms;
 
 /// <summary>
@@ -45,7 +47,7 @@ public class HBValidationMessageStoreTests
 
         editContext.ValidationErrors.Add(x => x.Address.City, "City is required.");
 
-        var fieldMessages = editContext.Context.GetValidationMessages(new(person.Address, nameof(Address.City)));
+        var fieldMessages = editContext.Context.GetValidationMessages(new FieldIdentifier(person.Address, nameof(Address.City)));
         Assert.Contains("City is required.", fieldMessages);
     }
 

--- a/tests/HeadlessBlazor.Tests/Forms/HBValidationMessageStoreTests.cs
+++ b/tests/HeadlessBlazor.Tests/Forms/HBValidationMessageStoreTests.cs
@@ -1,0 +1,93 @@
+namespace HeadlessBlazor.Tests.Forms;
+
+/// <summary>
+/// Layer 1 (pure logic) tests for <see cref="HBValidationMessageStore{TModel}"/>: adding and
+/// clearing messages by member-access expression, by field name, and for nested members.
+/// </summary>
+public class HBValidationMessageStoreTests
+{
+    private sealed class Address
+    {
+        public string? City { get; set; }
+    }
+
+    private sealed class Person
+    {
+        public string? Name { get; set; }
+        public Address Address { get; set; } = new();
+    }
+
+    [Fact]
+    public void Add_ByExpression_AddsAMessageForThatField()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        editContext.ValidationErrors.Add(x => x.Name, "Name is required.");
+
+        Assert.Contains("Name is required.", editContext.Context.GetValidationMessages());
+    }
+
+    [Fact]
+    public void Add_ByFieldName_AddsAMessageForThatField()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        editContext.ValidationErrors.Add(nameof(Person.Name), "Name is required.");
+
+        Assert.Contains("Name is required.", editContext.Context.GetValidationMessages());
+    }
+
+    [Fact]
+    public void Add_ForNestedMember_ResolvesTheNestedOwner()
+    {
+        var person = new Person();
+        var editContext = new HBEditContext<Person>(person);
+
+        editContext.ValidationErrors.Add(x => x.Address.City, "City is required.");
+
+        var fieldMessages = editContext.Context.GetValidationMessages(new(person.Address, nameof(Address.City)));
+        Assert.Contains("City is required.", fieldMessages);
+    }
+
+    [Fact]
+    public void AddRange_AddsAllMessages()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        editContext.ValidationErrors.AddRange(x => x.Name, ["Too short.", "Must not contain digits."]);
+
+        Assert.Equal(2, editContext.Context.GetValidationMessages().Count());
+    }
+
+    [Fact]
+    public void Clear_RemovesPreviouslyAddedMessages()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+        editContext.ValidationErrors.Add(x => x.Name, "Name is required.");
+
+        editContext.ValidationErrors.Clear();
+
+        Assert.Empty(editContext.Context.GetValidationMessages());
+    }
+
+    [Fact]
+    public void Clear_ByExpression_OnlyRemovesMessagesForThatField()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+        editContext.ValidationErrors.Add(x => x.Name, "Name is required.");
+        editContext.ValidationErrors.Add(x => x.Address.City, "City is required.");
+
+        editContext.ValidationErrors.Clear(x => x.Name);
+
+        Assert.Single(editContext.Context.GetValidationMessages());
+    }
+
+    [Fact]
+    public void Add_WithUnsupportedExpression_ThrowsArgumentException()
+    {
+        var editContext = new HBEditContext<Person>(new Person());
+
+        // A method call (rather than a member access) is not a supported field expression shape.
+        Assert.Throws<ArgumentException>(() => editContext.ValidationErrors.Add(x => x.ToString()!, "Invalid."));
+    }
+}

--- a/tests/HeadlessBlazor.Tests/HeadlessBlazor.Tests.csproj
+++ b/tests/HeadlessBlazor.Tests/HeadlessBlazor.Tests.csproj
@@ -24,7 +24,13 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\HeadlessBlazor.Core\HeadlessBlazor.Core.csproj" />
     <ProjectReference Include="..\..\src\HeadlessBlazor.DarkMode\HeadlessBlazor.DarkMode.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor.Dropdown\HeadlessBlazor.Dropdown.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor.FloatingElement\HeadlessBlazor.FloatingElement.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor.Forms\HeadlessBlazor.Forms.csproj" />
     <ProjectReference Include="..\..\src\HeadlessBlazor.Modal\HeadlessBlazor.Modal.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor.OutsideClick\HeadlessBlazor.OutsideClick.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor.Toast\HeadlessBlazor.Toast.csproj" />
+    <ProjectReference Include="..\..\src\HeadlessBlazor\HeadlessBlazor.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/HeadlessBlazor.Tests/OutsideClick/HBOutsideClickBehaviorTests.cs
+++ b/tests/HeadlessBlazor.Tests/OutsideClick/HBOutsideClickBehaviorTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.OutsideClick;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBOutsideClickBehavior"/>. As noted in
+/// CLAUDE.md, bUnit stubs <c>IJSRuntime</c> and cannot verify the real effects of JS-interop
+/// behaviors, so these tests assert the .NET-side contract (disposal guard, the
+/// <see cref="HBOutsideClickBehavior.NotifyClickOutside"/> callback) rather than driving the
+/// component through its JS-dependent render lifecycle. The actual outside-click detection is
+/// verified manually via the docs site.
+/// </summary>
+public class HBOutsideClickBehaviorTests
+{
+    [Fact]
+    public async Task DisposeAsync_DoesNotThrow_WhenNeverInitialized()
+    {
+        var behavior = new HBOutsideClickBehavior();
+
+        await behavior.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task NotifyClickOutside_InvokesOnClick()
+    {
+        var invoked = 0;
+        var behavior = new HBOutsideClickBehavior
+        {
+            OnClick = EventCallback.Factory.Create(this, () => invoked++)
+        };
+
+        behavior.NotifyClickOutside();
+
+        // NotifyClickOutside is `async void` (required by [JSInvokable]), so give its
+        // continuation a chance to run before asserting.
+        await Task.Delay(10);
+
+        Assert.Equal(1, invoked);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/HeadlessBlazor.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HeadlessBlazor.Tests;
+
+/// <summary>
+/// Layer 1 (pure logic) tests for the bundle package's <see cref="ServiceCollectionExtensions.AddHeadlessBlazor"/>,
+/// which just forwards to each component package's own DI registration.
+/// </summary>
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddHeadlessBlazor_RegistersModalService()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessBlazor();
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IModalService>());
+    }
+
+    [Fact]
+    public void AddHeadlessBlazor_RegistersToastService()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessBlazor();
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IToastService>());
+    }
+
+    [Fact]
+    public void AddHeadlessBlazor_AppliesConfiguredModalDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddHeadlessBlazor(configureModalDefaults: options => options.CloseOnEscape = false);
+        var provider = services.BuildServiceProvider();
+        var modalService = (ModalService)provider.GetRequiredService<IModalService>();
+
+        _ = modalService.ShowAsync<TestModal, bool>();
+
+        Assert.False(modalService.Instances[0].Options.CloseOnEscape);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/FakeToastInstance.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/FakeToastInstance.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// A minimal <see cref="IToastInstance"/> test double for asserting that components cascaded
+/// under a toast body (e.g. <see cref="HBToastClose"/>) call back into it correctly.
+/// </summary>
+internal sealed class FakeToastInstance : IToastInstance
+{
+    public Guid Id { get; } = Guid.NewGuid();
+
+    public ToastOptions Options { get; } = new();
+
+    public int DismissCallCount { get; private set; }
+
+    public Task DismissAsync()
+    {
+        DismissCallCount++;
+        return Task.CompletedTask;
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/FakeToastService.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/FakeToastService.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// A minimal <see cref="IToastService"/> test double for asserting that components which inject
+/// <see cref="IToastService"/> (e.g. <see cref="HBToastTrigger{TComponent}"/>) call it correctly,
+/// without going through the real service's instance tracking.
+/// </summary>
+internal sealed class FakeToastService : IToastService
+{
+    public IDictionary<string, object?>? LastParameters { get; private set; }
+
+    public ToastOptions? LastOptions { get; private set; }
+
+    public int ShowCallCount { get; private set; }
+
+    public ToastBuilder<TComponent> Create<TComponent>() where TComponent : IComponent => new(this);
+
+    public IToastInstance Show<TComponent>(ToastOptions? options = null) where TComponent : IComponent
+        => Show<TComponent>(new Dictionary<string, object?>(), options);
+
+    public IToastInstance Show<TComponent>(IDictionary<string, object?> parameters, ToastOptions? options = null) where TComponent : IComponent
+    {
+        ShowCallCount++;
+        LastParameters = parameters;
+        LastOptions = options;
+        return new FakeToastInstance();
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/HBToastCloseTests.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/HBToastCloseTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBToastClose"/>. No JS interop is involved
+/// here (dismissal is plain .NET), so these exercise the full render + click behavior via bUnit.
+/// </summary>
+public class HBToastCloseTests : BunitContext
+{
+    [Fact]
+    public void Throws_WhenNotCascadedFromAToastBody()
+    {
+        Assert.Throws<InvalidOperationException>(() => Render<HBToastClose>());
+    }
+
+    [Fact]
+    public void RendersButton_WithTypeButton()
+    {
+        var toast = new FakeToastInstance();
+
+        var cut = RenderWithToast(toast);
+
+        var button = cut.Find("button");
+        Assert.Equal("button", button.GetAttribute("type"));
+    }
+
+    [Fact]
+    public void Click_DismissesTheToast()
+    {
+        var toast = new FakeToastInstance();
+
+        var cut = RenderWithToast(toast);
+        cut.Find("button").Click();
+
+        Assert.Equal(1, toast.DismissCallCount);
+    }
+
+    private IRenderedComponent<HBToastClose> RenderWithToast(FakeToastInstance toast)
+    {
+        return Render<CascadingValue<IToastInstance>>(ps => ps
+            .Add(p => p.Value, toast)
+            .AddChildContent<HBToastClose>()).FindComponent<HBToastClose>();
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/HBToastTriggerTests.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/HBToastTriggerTests.cs
@@ -1,0 +1,44 @@
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// Layer 2 (rendered component) tests for <see cref="HBToastTrigger{TComponent}"/>. No JS interop
+/// is involved (showing a toast is plain .NET via the injected <see cref="IToastService"/>), so
+/// these exercise the full render + click behavior via bUnit against a fake service.
+/// </summary>
+public class HBToastTriggerTests : BunitContext
+{
+    [Fact]
+    public void RendersButton_WithTypeButton()
+    {
+        Services.AddSingleton<IToastService>(new FakeToastService());
+
+        var cut = Render<HBToastTrigger<TestToast>>();
+
+        Assert.Equal("button", cut.Find("button").GetAttribute("type"));
+    }
+
+    [Fact]
+    public void Click_ShowsTheToast()
+    {
+        var service = new FakeToastService();
+        Services.AddSingleton<IToastService>(service);
+
+        var cut = Render<HBToastTrigger<TestToast>>();
+        cut.Find("button").Click();
+
+        Assert.Equal(1, service.ShowCallCount);
+    }
+
+    [Fact]
+    public void Click_PassesConfiguredParameters()
+    {
+        var service = new FakeToastService();
+        Services.AddSingleton<IToastService>(service);
+        var parameters = new Dictionary<string, object?> { ["Message"] = "Saved" };
+
+        var cut = Render<HBToastTrigger<TestToast>>(ps => ps.Add(p => p.Parameters, parameters));
+        cut.Find("button").Click();
+
+        Assert.Same(parameters, service.LastParameters);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/HBToastTriggerTests.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/HBToastTriggerTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace HeadlessBlazor.Tests.Toast;
 
 /// <summary>

--- a/tests/HeadlessBlazor.Tests/Toast/TestToast.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/TestToast.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// Minimal component used as a toast body in service-level tests. <see cref="ToastService"/> only
+/// stores its <see cref="System.Type"/> and parameters (it never instantiates the component itself),
+/// so an empty body is enough to exercise the service.
+/// </summary>
+public sealed class TestToast : ComponentBase
+{
+    [Parameter] public string? Message { get; set; }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/ToastBuilderTests.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/ToastBuilderTests.cs
@@ -1,0 +1,44 @@
+namespace HeadlessBlazor.Tests.Toast;
+
+public class ToastBuilderTests
+{
+    private static ToastService CreateService() => new(new ToastOptions { Duration = null });
+
+    [Fact]
+    public void WithParam_BindsParameterByExpression()
+    {
+        var service = CreateService();
+
+        _ = service.Create<TestToast>().WithParam(x => x.Message, "Hello").Show();
+
+        Assert.Equal("Hello", service.Instances[0].Parameters["Message"]);
+    }
+
+    [Fact]
+    public void Show_CopiesParameters_SoLaterReuseDoesNotMutateShownToast()
+    {
+        var service = CreateService();
+        var builder = service.Create<TestToast>().WithParam(x => x.Message, "First");
+
+        _ = builder.Show();
+        var shownToastParameters = service.Instances[0].Parameters;
+
+        // Reconfiguring the same builder must not write into the already-shown toast's dictionary.
+        builder.WithParam(x => x.Message, "Second");
+
+        Assert.Equal("First", shownToastParameters["Message"]);
+    }
+
+    [Fact]
+    public void WithParam_LastValueWins()
+    {
+        var service = CreateService();
+
+        _ = service.Create<TestToast>()
+            .WithParam(x => x.Message, "First")
+            .WithParam(x => x.Message, "Last")
+            .Show();
+
+        Assert.Equal("Last", service.Instances[0].Parameters["Message"]);
+    }
+}

--- a/tests/HeadlessBlazor.Tests/Toast/ToastServiceTests.cs
+++ b/tests/HeadlessBlazor.Tests/Toast/ToastServiceTests.cs
@@ -1,0 +1,103 @@
+namespace HeadlessBlazor.Tests.Toast;
+
+/// <summary>
+/// Layer 1 (pure logic) tests for <see cref="ToastService"/>: instance tracking, the
+/// <c>StateChanged</c> signal, auto-dismiss, and the double-dismiss guard. No rendering and no
+/// JS interop is involved, so these run as plain unit tests against the service directly.
+/// </summary>
+public class ToastServiceTests
+{
+    private static ToastService CreateService(ToastOptions? defaults = null) => new(defaults ?? new ToastOptions { Duration = null });
+
+    [Fact]
+    public void Show_AddsInstance_AndRaisesStateChanged()
+    {
+        var service = CreateService();
+        var raised = 0;
+        service.StateChanged += () => raised++;
+
+        service.Show<TestToast>();
+
+        Assert.Single(service.Instances);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void Show_FallsBackToDefaultOptions_WhenNoneProvided()
+    {
+        var defaults = new ToastOptions { Duration = null };
+        var service = CreateService(defaults);
+
+        service.Show<TestToast>();
+
+        Assert.Same(defaults, service.Instances[0].Options);
+    }
+
+    [Fact]
+    public void Show_UsesProvidedOptions_OverDefaults()
+    {
+        var service = CreateService();
+        var options = new ToastOptions { Duration = null };
+
+        service.Show<TestToast>(options);
+
+        Assert.Same(options, service.Instances[0].Options);
+    }
+
+    [Fact]
+    public void Instances_AreOrderedOldestFirst()
+    {
+        var service = CreateService();
+
+        service.Show<TestToast>();
+        _ = service.Create<TestToast>().WithParam(x => x.Message, "second").Show();
+
+        Assert.Equal(2, service.Instances.Count);
+        Assert.False(service.Instances[0].Parameters.ContainsKey("Message"));
+        Assert.Equal("second", service.Instances[1].Parameters["Message"]);
+    }
+
+    [Fact]
+    public async Task DismissAsync_RemovesInstance_AndRaisesStateChanged_WhenTransitionsDisabled()
+    {
+        var service = CreateService();
+        var instance = service.Show<TestToast>();
+        var raised = 0;
+        service.StateChanged += () => raised++;
+
+        await instance.DismissAsync();
+
+        Assert.Empty(service.Instances);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public async Task DismissAsync_MarksLeaving_ThenRemoves_WhenTransitionsEnabled()
+    {
+        var service = CreateService(new ToastOptions { Duration = null, TransitionDuration = TimeSpan.FromMilliseconds(1) });
+        var instance = service.Show<TestToast>();
+        var toastInstance = (ToastInstance)instance;
+
+        var dismissTask = instance.DismissAsync();
+
+        // Still mounted (in its "leaving" phase) until the transition duration elapses.
+        Assert.Single(service.Instances);
+        Assert.Equal("closed", toastInstance.DataState);
+
+        await dismissTask;
+
+        Assert.Empty(service.Instances);
+    }
+
+    [Fact]
+    public async Task DismissAsync_Twice_IsNoOp()
+    {
+        var service = CreateService();
+        var instance = service.Show<TestToast>();
+
+        await instance.DismissAsync();
+        await instance.DismissAsync();
+
+        Assert.Empty(service.Instances);
+    }
+}


### PR DESCRIPTION
Adds initial, low-hanging-fruit tests for every remaining `src` package (Toast, Dropdown, OutsideClick, FloatingElement, Forms, and the bundle package), following the two-layer pattern (pure-logic xUnit vs. rendered-component bUnit) already established for Modal/DarkMode.

Closes #24.

**Note:** I was unable to run `dotnet build`/`dotnet test` in my sandbox (no `dotnet` tool access) - please run the test suite before merging.

Generated with [Claude Code](https://claude.ai/code)